### PR TITLE
refactor(schema/music-reactive): process empty return

### DIFF
--- a/core/music-reactive/src/main/java/com/github/durex/music/service/MusicService.java
+++ b/core/music-reactive/src/main/java/com/github/durex/music/service/MusicService.java
@@ -34,7 +34,9 @@ public class MusicService {
             e -> {
               log.error(e.getMessage(), e);
               throw new ApiException("Error finding music by id: " + id, ENTITY_NOT_FOUND);
-            });
+            })
+        .switchIfEmpty(
+            Mono.error(new ApiException("Music not found by id:" + id, ENTITY_NOT_FOUND)));
   }
 
   public Flux<Music> getMusicsByTitle(@NotNull String title) {
@@ -44,7 +46,9 @@ public class MusicService {
             e -> {
               log.error(e.getMessage(), e);
               throw new ApiException("Error finding music by title: " + title, ENTITY_NOT_FOUND);
-            });
+            })
+        .switchIfEmpty(
+            Flux.error(new ApiException("Music not found by title:" + title, ENTITY_NOT_FOUND)));
   }
 
   public Flux<Music> getMusicsByTitle(@NotNull String title, WildCardType wildCardEnum) {
@@ -56,7 +60,9 @@ public class MusicService {
             e -> {
               log.error(e.getMessage(), e);
               throw new ApiException("Error finding music by title: " + title, ENTITY_NOT_FOUND);
-            });
+            })
+        .switchIfEmpty(
+            Flux.error(new ApiException("Music not found by title:" + title, ENTITY_NOT_FOUND)));
   }
 
   public Mono<Integer> createMusic(Music music) {

--- a/core/music-reactive/src/main/java/com/github/durex/music/service/PlaylistService.java
+++ b/core/music-reactive/src/main/java/com/github/durex/music/service/PlaylistService.java
@@ -37,7 +37,10 @@ public class PlaylistService {
               log.error(e.getMessage(), e);
               throw new ApiException("Error find playlist by title : " + title, ENTITY_NOT_FOUND);
             })
-        .doOnNext(playList -> log.info("find playlist by title with id: {}", playList.getId()));
+        .doOnNext(playList -> log.info("find playlist by title with id: {}", playList.getId()))
+        .switchIfEmpty(
+            Flux.error(
+                new ApiException("Error find playlist by title: " + title, ENTITY_NOT_FOUND)));
   }
 
   public Flux<PlayList> findPlayListByTitle(@NotNull String title, WildCardType wildcard) {
@@ -51,7 +54,10 @@ public class PlaylistService {
                   String.format("Error find playlist by title %s, wildcard: %s", title, wildcard);
               throw new ApiException(message, ENTITY_NOT_FOUND);
             })
-        .doOnNext(playList -> log.info("find playlist by title with id: {}", playList.getId()));
+        .doOnNext(playList -> log.info("find playlist by title with id: {}", playList.getId()))
+        .switchIfEmpty(
+            Flux.error(
+                new ApiException("Error find playlist by title: " + title, ENTITY_NOT_FOUND)));
   }
 
   public Mono<PlayList> findPlayListById(@NotNull String id) {
@@ -62,7 +68,9 @@ public class PlaylistService {
             e -> {
               log.error(e.getMessage(), e);
               throw new ApiException("Error find playlist by id: " + id, ENTITY_NOT_FOUND);
-            });
+            })
+        .switchIfEmpty(
+            Mono.error(new ApiException("Error find playlist by id: " + id, ENTITY_NOT_FOUND)));
   }
 
   public Flux<PlayList> findPlayList() {
@@ -73,7 +81,8 @@ public class PlaylistService {
               log.error(e.getMessage(), e);
               throw new ApiException("Error find all playlist");
             })
-        .doOnComplete(() -> log.info("find all playlist"));
+        .doOnComplete(() -> log.info("find all playlist"))
+        .switchIfEmpty(Flux.error(new ApiException("Error find all playlist", ENTITY_NOT_FOUND)));
   }
 
   public Flux<Integer> createPlaylist(PlayList playList, List<Music> musics) {

--- a/core/music-reactive/src/test/java/com/github/durex/music/service/PlaylistServiceTest.java
+++ b/core/music-reactive/src/test/java/com/github/durex/music/service/PlaylistServiceTest.java
@@ -37,8 +37,20 @@ class PlaylistServiceTest {
   }
 
   @Test
-  @DisplayName("When find playlist by title and not found")
-  void testFindPlayListByTitleWithException() {
+  @DisplayName("When find playlist by title return empty")
+  void testFindPlayListByTitleReturnEmpty() {
+    var playLists = DemoMusicData.givenSomePlayList(5);
+    Mockito.when(repository.findByTitle("test")).thenReturn(Flux.empty());
+    service
+        .findPlayListByTitle("test")
+        .as(StepVerifier::create)
+        .expectError(ApiException.class)
+        .verify();
+  }
+
+  @Test
+  @DisplayName("When find playlist by title return exception")
+  void testFindPlayListByTitleReturnException() {
     Mockito.when(repository.findByTitle("test"))
         .thenReturn(Flux.error(new ApiException("not found")));
     service
@@ -73,6 +85,17 @@ class PlaylistServiceTest {
   }
 
   @Test
+  @DisplayName("When find playlist by titile with wildcard return empty")
+  void testFindPlayListByTitleWithWildCardReturnEmpty() {
+    Mockito.when(repository.findByTitle(any(), any())).thenReturn(Flux.empty());
+    service
+        .findPlayListByTitle("test", WildCardType.CONTAINS)
+        .as(StepVerifier::create)
+        .expectError(ApiException.class)
+        .verify();
+  }
+
+  @Test
   @DisplayName("When find playlist by id")
   void testFindPlayListById() {
     Mockito.when(repository.findById(any())).thenReturn(Mono.just(DemoMusicData.givenAPlayList()));
@@ -84,9 +107,20 @@ class PlaylistServiceTest {
   }
 
   @Test
-  @DisplayName("When find playlist by id and not found")
+  @DisplayName("When find playlist by id return exception")
   void testFindPlayListByIdWithException() {
     Mockito.when(repository.findById(any())).thenReturn(Mono.error(new ApiException("not found")));
+    service
+        .findPlayListById(UniqID.getId())
+        .as(StepVerifier::create)
+        .expectError(ApiException.class)
+        .verify();
+  }
+
+  @Test
+  @DisplayName("When find playlist by id return empty")
+  void testFindPlayListByIdReturnEmpty() {
+    Mockito.when(repository.findById(any())).thenReturn(Mono.empty());
     service
         .findPlayListById(UniqID.getId())
         .as(StepVerifier::create)
@@ -103,9 +137,16 @@ class PlaylistServiceTest {
   }
 
   @Test
+  @DisplayName("When find all playlist return exception")
+  void testFindAllPlayListReturnException() {
+    Mockito.when(repository.findAll()).thenReturn(Flux.error(new ApiException("not found")));
+    service.findPlayList().as(StepVerifier::create).expectError(ApiException.class).verify();
+  }
+
+  @Test
   @DisplayName("When find all playlist and not found")
   void testFindAllPlayListWithException() {
-    Mockito.when(repository.findAll()).thenReturn(Flux.error(new ApiException("not found")));
+    Mockito.when(repository.findAll()).thenReturn(Flux.empty());
     service.findPlayList().as(StepVerifier::create).expectError(ApiException.class).verify();
   }
 


### PR DESCRIPTION
refactor(schema/music-reactive): process empty return
-[x] throw exception when flux/mono return empty in search crud